### PR TITLE
Change API/tile URLs to protocol-relative URLs

### DIFF
--- a/js/getdata.js
+++ b/js/getdata.js
@@ -60,7 +60,7 @@ Freeway.prototype.getFreewayData = function(opt) {
 	console.time('getFreewayData');
 	var query = '[out:json][timeout:'+opt.timeout+'];(relation('+this.relID+');way(r);node(w););out bb body qt;';
 	var fwy = this;
-	rq1[this.relID] = $.getJSON('http://overpass-api.de/api/interpreter?data=' + query,
+	rq1[this.relID] = $.getJSON('//overpass-api.de/api/interpreter?data=' + query,
 		function (response) {
 			if(response.remark!=undefined) {
 				console.timeEnd('getFreewayData');
@@ -142,7 +142,7 @@ Freeway.prototype.getDestinationUnmarked = function(opt) {
 	console.time('getDestinationUnmarked');
 	var query = '[out:json][timeout:'+opt.timeout+'];relation('+this.relID+');way(r);node(w);way(bn);out body qt;';
 	var fwy = this;
-	rq2[this.relID] = $.getJSON('http://overpass-api.de/api/interpreter?data=' + query,
+	rq2[this.relID] = $.getJSON('//overpass-api.de/api/interpreter?data=' + query,
 		function (response) {
 			if (response.remark!=undefined) {
 				console.timeEnd('getDestinationUnmarked');
@@ -202,7 +202,7 @@ Freeway.prototype.getAreas = function(opt) {
 	var query = '[out:json][timeout:'+opt.timeout+'];relation(' + this.relID + ');way(r);node(w);(node(around:500)["highway"~"services|rest_' +
 		'area"]->.x;way(around:500)["highway"~"services|rest_area"];);(._;>;);out center qt;';
 	var fwy = this;
-	rq3[this.relID] = $.getJSON('http://overpass-api.de/api/interpreter?data=' + query,
+	rq3[this.relID] = $.getJSON('//overpass-api.de/api/interpreter?data=' + query,
 		function (response) {
 			if (response.remark!=undefined) { 
 				console.timeEnd('getAreas');
@@ -258,7 +258,7 @@ function searchInMap (opt) {
 	var query = '[out:json][timeout:'+opt.timeout+'];relation[route=road]('+
 		map.getBounds().getSouth()+','+map.getBounds().getWest()+','+map.getBounds().getNorth()+','+map.getBounds().getEast()+
 		');foreach(out tags; way(r); out tags 1 qt;);';
-	rq0 = $.getJSON('http://overpass-api.de/api/interpreter?data=' + query,
+	rq0 = $.getJSON('//overpass-api.de/api/interpreter?data=' + query,
 		function (response) {
 			if (response.remark!=undefined) { 
 				console.timeEnd('searchInMap');
@@ -308,7 +308,7 @@ function searchByProp (opt) {
 		(network!=''?'[network~"'+network+'"]':'')+
 		(operator!=''?'[operator~"'+operator+'"]':'')+
 		';foreach(out tags; way(r); out tags 1 qt;);';
-	rq0 = $.getJSON('http://overpass-api.de/api/interpreter?data=' + query,
+	rq0 = $.getJSON('//overpass-api.de/api/interpreter?data=' + query,
 		function (response) {
 			if (response.remark!=undefined) { 
 				console.timeEnd('searchByProp');

--- a/js/main.js
+++ b/js/main.js
@@ -11,7 +11,7 @@ if (options.lat==undefined && options.lon==undefined && options.z==undefined && 
 }
 
 a=L.tileLayer(
-	'http://api.tiles.mapbox.com/v4/k1wi.800a80e3/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiazF3aSIsImEiOiJaX0JKRUNzIn0.yL_KftGNvh631-_yDzotcQ', {
+	'//api.tiles.mapbox.com/v4/k1wi.800a80e3/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiazF3aSIsImEiOiJaX0JKRUNzIn0.yL_KftGNvh631-_yDzotcQ', {
 		attribution: '<a href="http://openstreetmap.org" title="OpenStreetMap">OSM</a> | <a href="http://mapbox.com" title="Tiles by Mapbox">Mapbox</a> ',
 		maxZoom: 18})
 	.addTo(map);


### PR DESCRIPTION
This fixes mixed content error when loading checkautopista2 over https://k1wiosm.github.io/checkautopista2/

Some consider protocol-less URLs an antipattern, and recommend always fetching https assets when you can: http://www.paulirish.com/2010/the-protocol-relative-url/