### PR TITLE
fix url of mapillary tiles

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -21,7 +21,7 @@ tileOSM=L.tileLayer(
 		maxZoom: 18});
 
 tileMapillary=L.vectorGrid.protobuf(
-	'http://d2munx5tg0hw47.cloudfront.net/tiles/{z}/{x}/{y}.mapbox', {
+	'https://d2munx5tg0hw47.cloudfront.net/tiles/{z}/{x}/{y}.mapbox', {
 		rendererFactory: L.canvas.tile,
 		vectorTileLayerStyles: {
 			'mapillary-sequences': {


### PR DESCRIPTION
it was only change the protocol of the URL as [the blog](http://blog.mapillary.com/update/2015/05/27/vectortiles.html) says.

fixes of #12 